### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Credits goes to https://twitter.com/theSeanCook for doing the sample. 
-I just cleaned it up, added a way to manage credentials with keychain and put it up on Cocoapods - since I needed it as a dependency for http://github.com/seivan/SHOmniAuthTwitter
+I just cleaned it up, added a way to manage credentials with keychain and put it up on CocoaPods - since I needed it as a dependency for http://github.com/seivan/SHOmniAuthTwitter
 
 It's probably better to use http://github.com/seivan/SHOmniAuthTwitter for your project as it handles edge cases and errors better.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
